### PR TITLE
get_h_data: fix too early return

### DIFF
--- a/lib/tushare/stock/trading.rb
+++ b/lib/tushare/stock/trading.rb
@@ -287,7 +287,6 @@ module Tushare
                        .uniq
         _write_head
         result = _parse_fq_data(_get_index_url(index, code, qs[0]), index)
-        return [] if result.empty?
         if qs.length > 1
           1.upto(qs.length - 1).each do |i|
             _write_console
@@ -295,6 +294,7 @@ module Tushare
                                          index)
           end
         end
+        return [] if result.empty?
         sorted_result = result.sort_by { |object| Date.strptime(object['date'], '%F') }
         last_date = sorted_result.last['date']
         result = result.uniq { |object| object['date'] }.select do |object|


### PR DESCRIPTION
In PR #35, result was not containt all trade data before checking emptiness.
```ruby
result = _parse_fq_data(_get_index_url(index, code, qs[0]), index)
return [] if result.empty?  #!return too early!
```
move code  `return [] if result.empty?` just before `sorted_result = result.sort_by...`
Sorry.