### PR TITLE
#fix# fix get_tick_data csv col_seq option, from '\t' to ''

### DIFF
--- a/lib/tushare/stock/trading.rb
+++ b/lib/tushare/stock/trading.rb
@@ -90,7 +90,7 @@ module Tushare
         resp = HTTParty.get(url)
         if resp.code.to_s == '200'
           tb_value = resp.body.encode('utf-8', 'gbk')
-          CSV.new(tb_value, headers: :first_row, encoding: 'utf-8', col_sep: '\t').map { |a| Hash[TICK_COLUMNS.zip(a.fields)] }
+          CSV.new(tb_value, headers: :first_row, encoding: 'utf-8', col_sep: ' ').map { |a| Hash[TICK_COLUMNS.zip(a.fields)] }
         else
           []
         end


### PR DESCRIPTION
CSV option ` col_seq: '\t' ` does not parse CSV file correctly,
use ` col_seq: ' ' `  instead.