### PR TITLE
fix new_stock api, last_page_guard check error

### DIFF
--- a/lib/tushare/stock/reference.rb
+++ b/lib/tushare/stock/reference.rb
@@ -201,7 +201,11 @@ module Tushare
           arr.map(&:content).map(&:strip)
         end
         last_page_guard = lambda do |doc|
-          doc.css('table.table2 tr:first td:first a').last.text != '尾页'
+          if doc.css('table.table2 tr:first td:first a').size > 0
+            doc.css('table.table2 tr:first td:first a').last.text != '尾页'
+          else
+            true
+          end
         end
         get_data(1, NEW_STOCKS_COLS, doc_generator, row_finder,
                  row_processor, last_page_guard)


### PR DESCRIPTION
There is a chance that `doc.css('table.table2 tr:first td:first a')` returns `[]`, a zero size array.
So the previous version, `doc.css('table.table2 tr:first td:first a').last.text != '尾页'` will raise an error.